### PR TITLE
feat: 🎸 proxyURL in GeocodingOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can find a comprehensive tutorial for using this module [on the OpenCage sit
 
 Sign up for a [free-trial API Key](https://opencagedata.com/users/sign_up).
 
-## node
+## NodeJS
 
 First install the library with `npm` or `yarn`:
 
@@ -156,8 +156,7 @@ input: [GeocodingRequest](./src/types/GeocodingRequest.ts)
 | Parameter | Type   | Optional? | Description                                                                                                                                                   |
 | --------- | ------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | q         | String | mandatory | the query string to be geocoded: a place name, address or coordinates as lat,long                                                                             |
-| key       | String | optional  | the `key` can be omitted when using a `proxyURL` or when using node with a dedicated environment variable `OPENCAGE_API_KEY`                                  |
-| proxyURL  | String | optional  | The proxy URL parameter (useful to hide your API key)                                                                                                         |
+| key       | String | optional  | the `key` can be omitted when using an `options.proxyURL` or when using a node runtime with a dedicated environment variable `OPENCAGE_API_KEY`               |
 | ...       | ...    | optional  | Check the [type definition](./src/types/GeocodingRequest.ts) and the [API documentation](https://opencagedata.com/api#request) for the other input parameters |
 
 options?: _additional optional options_
@@ -165,6 +164,7 @@ options?: _additional optional options_
 | Parameter | Type        | Optional? | Description                                                                                                 |
 | --------- | ----------- | --------- | ----------------------------------------------------------------------------------------------------------- |
 | signal    | AbortSignal | optional  | The [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) allow to cancel the request |
+| proxyURL  | String      | optional  | The proxy URL parameter (useful to hide your API key)                                                       |
 
 ### Error handling
 

--- a/src/errors/GeocodeError.ts
+++ b/src/errors/GeocodeError.ts
@@ -28,6 +28,11 @@ export class GeocodeError extends Error {
    * The status error object
    */
   status?: GeocodeErrorStatus;
+  /**
+   * Constructor for the GeocodeError class
+   *
+   * @param message the error message
+   */
   constructor(message: string) {
     super(message);
     this.name = 'GeocodeError';

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,7 +1,34 @@
+import { GeocodeError } from './errors/GeocodeError';
 import { version } from './version';
-import { checkFetchStatus, parseJSON } from './helpers/geocodeHelpers';
 
 const USER_AGENT = `OpenCageData Geocoding NodeJS API Client/${version}`;
+
+/**
+ * @private
+ * @description checks the response status and throws an error if the status is not ok
+ * @param response {Response} the response object
+ * @returns {Response} the response object
+ * @throws {GeocodeError} the error object
+ */
+export function checkFetchStatus(response: Response) {
+  if (response.status >= 200 && response.status < 300) {
+    return response;
+  }
+  // console.debug('request failed with status', response.status);
+  // console.debug('request failed with status text', response.statusText);
+  const message = response.statusText || `HTTP error ${response.status}`;
+  const error = new GeocodeError(message);
+  error.status = {
+    code: response.status,
+    message,
+  };
+  error.response = response;
+  throw error;
+}
+
+export function parseJSON(response: Response) {
+  return response.json();
+}
 
 /**
  * fetches the url and returns a promise

--- a/src/geocode.ts
+++ b/src/geocode.ts
@@ -1,5 +1,6 @@
-import { GeocodingRequest } from './types/GeocodingRequest';
-import { GeocodingResponse } from './types/GeocodingResponse';
+import type { GeocodingRequest } from './types/GeocodingRequest';
+import type { GeocodingResponse } from './types/GeocodingResponse';
+import type { GeocodingOptions } from './types/GeocodingOptions';
 import { fetchUrl } from './fetch';
 import {
   buildValidationError,
@@ -15,18 +16,22 @@ const MISSING_API_KEY = 'missing API key';
  * geocode address and reverse geocode coordinates using
  * [OpenCage API](https://opencagedata.com/api) requesting the json format.
  *
- * @param  {Object} input the input query parameter as JSON object,
+ * @param  {GeocodingRequest} input the input query parameter as JSON object,
  *  the attribute `q` is required, the `key` can be omitted when using
  *  a `proxyURL`, and when using node with a dedicated environment variable
  *  (OPENCAGE_API_KEY).
  *  Others optional parameters can be found at OpenCage Data API
  *  [documentation](https://opencagedata.com/api#forward-opt)
  *
- * @return {Promise} a promise resolved by the json format API payload
+ * @param  {Object} options the options object,
+ *  the attribute `signal` is used to abort the request when the signal is aborted.
+ *  the attribute `proxyURL` is used to proxy the request to a different URL.
+ *
+ * @return {Promise<GeocodingResponse>} a promise resolved by the json format API payload
  */
 export async function geocode(
   input: GeocodingRequest,
-  options?: { signal?: AbortSignal }
+  options?: GeocodingOptions
 ): Promise<GeocodingResponse> {
   return new Promise((resolve, reject) => {
     if (isUndefinedOrNull(input)) {
@@ -34,7 +39,7 @@ export async function geocode(
       reject(error);
       return;
     }
-    const params = buildQuery(input);
+    const params = buildQuery(input, options);
     if (params.missingKey) {
       const error = buildValidationError(401, MISSING_API_KEY);
       reject(error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export type {
   GeocodingRequest,
   GeocodeRequest,
 } from './types/GeocodingRequest';
+export type { GeocodingOptions } from './types/GeocodingOptions';
 export type { GeocodingResponse } from './types/GeocodingResponse';
 
 /**

--- a/src/types/GeocodingOptions.ts
+++ b/src/types/GeocodingOptions.ts
@@ -1,0 +1,16 @@
+/**
+ * GeocodingOptions type
+ *
+ * Represents the options object for the geocoding request
+ */
+export type GeocodingOptions = {
+  /**
+   * The AbortSignal to cancel the request.
+   */
+  signal?: AbortSignal;
+  /**
+   * The URL of the proxy server to use for the request.
+   * If provided, the API key can be omitted from the request.
+   */
+  proxyURL?: string;
+};

--- a/src/types/GeocodingRequest.ts
+++ b/src/types/GeocodingRequest.ts
@@ -1,5 +1,5 @@
 /**
- * GeocodeRequest and related request parameters for the OpenCage API.
+ * GeocodingRequest and related request parameters for the OpenCage API.
  */
 export type GeocodingRequest = {
   /**
@@ -10,10 +10,6 @@ export type GeocodingRequest = {
    * the query string to be geocoded: a latitude, longitude or a place name/address.
    */
   q: string;
-  /**
-   * The URL of a proxy server to use for the request. This is useful if you want to hide your API Key.
-   */
-  proxyURL?: string;
   /**
    * When set to 1 we attempt to abbreviate and shorten the formatted string we return. Learn more about formatted placename.
    */
@@ -29,7 +25,6 @@ export type GeocodingRequest = {
    * Example usage:
    * bounds=-0.563160,51.280430,0.278970,51.683979
    */
-
   bounds?: string;
   /**
    * Used only for forward geocoding. Restricts results to the specified country/territory or countries.
@@ -112,6 +107,11 @@ export type GeocodingRequest = {
    * As an example, by default a reverse geocoding request for the coordinates 50.976004, 11.336753 returns a formatted value of Goethes Gartenhaus, Corona-Schröter-Weg 1, 99425 Weimar, Germany, but if address_only=1 is specified the value would be simply Corona-Schröter-Weg 1, 99425 Weimar, Germany. This can be particularly useful when there are many stores/restaurants/whatever at a single location (for example a multi-story building).
    */
   address_only?: number;
+  /**
+   * @deprecated Use `GeocodingOptions.proxyURL` instead.
+   * The URL of a proxy server to use for the request. This is useful if you want to hide your API Key.
+   */
+  proxyURL?: string;
 };
 
 // Exporting GeocodeRequest type as an alias for GeocodingRequest

--- a/tests/fetch.spec.ts
+++ b/tests/fetch.spec.ts
@@ -84,4 +84,22 @@ describe('fetchUrl', () => {
       })
     ).rejects.toMatchObject({ status: { code: 404, message: 'Not Found' } });
   });
+
+  it('rejects with fallback error message if response statusText is empty (browser CORS simulation)', async () => {
+    const url = 'https://api.opencagedata.com/';
+    const mockResponse = {
+      status: 403,
+      statusText: '', // Simulate CORS: statusText is empty
+      json: () => Promise.resolve({}),
+    };
+    global.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+    await expect(
+      new Promise((resolve, reject) => {
+        fetchUrl(url, resolve, reject);
+      })
+    ).rejects.toMatchObject({
+      status: { code: 403, message: 'HTTP error 403' },
+    });
+  });
 });

--- a/tests/geocode.spec.ts
+++ b/tests/geocode.spec.ts
@@ -18,7 +18,7 @@ describe('geocode tests', () => {
     it('tests no input parameters [browser]', async () => {
       const input = undefined;
       try {
-        // @ts-expect-error Argument of type 'undefined' is not assignable to parameter of type 'GeocodeRequest'.ts(2345)
+        // @ts-expect-error Argument of type 'undefined' is not assignable to parameter of type 'GeocodingRequest'.ts(2345)
         await opencage.geocode(input);
       } catch (error) {
         // console.log(error);
@@ -28,7 +28,7 @@ describe('geocode tests', () => {
     it('tests a null input parameter [browser]', async () => {
       const input = null;
       try {
-        // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'GeocodeRequest'.ts(2345)
+        // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'GeocodingRequest'.ts(2345)
         await opencage.geocode(input);
       } catch (error) {
         // console.log(error);
@@ -43,6 +43,23 @@ describe('geocode tests', () => {
         // console.log(error);
         expect(error.response.status.code).toEqual(401);
       }
+    });
+  });
+  describe('abort tests', () => {
+    it('aborts the geocode request when signal is aborted', async () => {
+      // Provide a dummy API key to avoid the missing key error
+      const input = { q: 'lyon', key: 'test' };
+      const controller = new AbortController();
+
+      // Start the geocode request
+      const promise = opencage.geocode(input, { signal: controller.signal });
+
+      // Abort the request almost immediately
+      controller.abort();
+
+      await expect(promise).rejects.toMatchObject({
+        name: 'AbortError',
+      });
     });
   });
 });

--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   isUndefinedOrEmpty,
   isUndefinedOrNull,
+  buildQuery,
 } from '../src/helpers/geocodeHelpers';
 
 describe('Helpers library', () => {
@@ -71,6 +72,84 @@ describe('Helpers library', () => {
       const input = null;
       const result = isUndefinedOrNull(input);
       expect(result).toBe(true);
+    });
+  });
+  describe('function buildQuery', () => {
+    const defaultInput = { key: 'test-key', q: 'Berlin' };
+
+    it('returns correct endpoint and query when no proxyURL and key provided', () => {
+      const result = buildQuery(defaultInput);
+      expect(result.endpoint).toBe('https://api.opencagedata.com/geocode/v1/json');
+      expect(result.missingKey).toBe(false);
+      expect(result.query).toEqual(defaultInput);
+    });
+
+    it('removes proxyURL from query and uses it as endpoint (input.proxyURL)', () => {
+      const input = { ...defaultInput, proxyURL: 'https://proxy.example.com' };
+      const result = buildQuery(input);
+      expect(result.endpoint).toBe('https://proxy.example.com');
+      expect(result.query.proxyURL).toBeUndefined();
+      expect(result.missingKey).toBe(false);
+    });
+
+    it('removes proxyURL from query and uses it as endpoint (options.proxyURL)', () => {
+      const input = { ...defaultInput };
+      const options = { proxyURL: 'https://proxy2.example.com' };
+      const result = buildQuery(input, options);
+      expect(result.endpoint).toBe('https://proxy2.example.com');
+      expect(result.query.proxyURL).toBeUndefined();
+      expect(result.missingKey).toBe(false);
+    });
+
+    it('prefers options.proxyURL over input.proxyURL', () => {
+      const input = { ...defaultInput, proxyURL: 'https://proxy.example.com' };
+      const options = { proxyURL: 'https://proxy2.example.com' };
+      const result = buildQuery(input, options);
+      expect(result.endpoint).toBe('https://proxy2.example.com');
+      expect(result.query.proxyURL).toBeUndefined();
+    });
+
+    it('uses input.proxyURL if options.proxyURL is empty', () => {
+      const input = { ...defaultInput, proxyURL: 'https://proxy.example.com' };
+      const options = { proxyURL: '' };
+      const result = buildQuery(input, options);
+      expect(result.endpoint).toBe('https://proxy.example.com');
+      expect(result.query.proxyURL).toBeUndefined();
+    });
+
+    it('sets missingKey true if key is missing and process.env.OPENCAGE_API_KEY is undefined', () => {
+      const input = { q: 'Berlin' };
+      const originalEnv = process.env.OPENCAGE_API_KEY;
+      delete process.env.OPENCAGE_API_KEY;
+      const result = buildQuery(input);
+      expect(result.missingKey).toBe(true);
+      process.env.OPENCAGE_API_KEY = originalEnv;
+    });
+
+    it('uses process.env.OPENCAGE_API_KEY if key is missing in input', () => {
+      const input = { q: 'Berlin' };
+      const originalEnv = process.env.OPENCAGE_API_KEY;
+      process.env.OPENCAGE_API_KEY = 'env-key';
+      const result = buildQuery(input);
+      expect(result.query.key).toBe('env-key');
+      expect(result.missingKey).toBe(false);
+      process.env.OPENCAGE_API_KEY = originalEnv;
+    });
+
+    it('handles empty input object', () => {
+      // GeocodingRequest requires at least 'q' (query string)
+      const result = buildQuery({ q: '' });
+      expect(result.endpoint).toBe('https://api.opencagedata.com/geocode/v1/json');
+      // missingKey should be true if no key and no env
+      expect(typeof result.missingKey).toBe('boolean');
+      expect(typeof result.query).toBe('object');
+    });
+
+    it('handles undefined options', () => {
+      const result = buildQuery(defaultInput, undefined);
+      expect(result.endpoint).toBe('https://api.opencagedata.com/geocode/v1/json');
+      expect(result.missingKey).toBe(false);
+      expect(result.query).toEqual(defaultInput);
     });
   });
 });

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -31,49 +31,40 @@ describe('integration tests', () => {
     const input = {
       q: 'Brandenburg Gate',
     };
-    // try {
     const data = await opencage.geocode(input);
     expect(data).toBeTruthy();
-    // } catch (error) {
-    //   console.log(error);
-    // }
   });
   it('reverse geocodes Brandenburg Gate with space', async () => {
-    // expect.assertions(1);
     const input = {
       q: '52.5162767 13.3777025',
     };
-    // try {
     const data = await opencage.geocode(input);
     expect(data).toBeTruthy();
-    // } catch (error) {
-    //   console.log(error);
-    // }
   });
   it('reverse geocodes Brandenburg Gate with comma', async () => {
-    // expect.assertions(1);
     const input = {
       q: '52.5162767,13.3777025',
     };
-    // try {
     const data = await opencage.geocode(input);
     expect(data).toBeTruthy();
-    // } catch (error) {
-    //   console.log(error);
-    // }
   });
   it('reverse geocodes Brandenburg Gate with space and comma', async () => {
-    // expect.assertions(1);
     const input = {
       q: '52.5162767, 13.3777025',
     };
-    // try {
     const data = await opencage.geocode(input);
     expect(data).toBeTruthy();
-    // } catch (error) {
-    //   console.log(error);
-    // }
   });
+
+  /**
+   * Proxy tests
+   *
+   * These tests are only run if the PROXY_URL environment variable is set.
+   *
+   * The PROXY_URL environment variable is used to proxy the request to a different URL.
+   *
+   * The PROXY_URL environment variable is used to proxy the request to a different URL.
+   */
   describe('proxy tests', () => {
     if (!process.env.PROXY_URL) {
       it('No Proxy set', () => {
@@ -100,18 +91,24 @@ describe('integration tests', () => {
         // Everything else is truthy.
         expect(proxyURL).toBeTruthy();
       });
-      it('geocodes Brandenburg Gate via proxy', async () => {
-        // expect.assertions(1);
+
+      it('geocodes Brandenburg Gate via proxy in GeocodingRequest', async () => {
         const input = {
           q: 'Brandenburg Gate',
           proxyURL,
         };
-        // try {
         const data = await opencage.geocode(input);
         expect(data).toBeTruthy();
-        // } catch (error) {
-        //   console.log(error);
-        // }
+      });
+      it('geocodes Brandenburg Gate via proxy in GeocodingOptions', async () => {
+        const input = {
+          q: 'Brandenburg Gate',
+        };
+        const options = {
+          proxyURL,
+        };
+        const data = await opencage.geocode(input, options);
+        expect(data).toBeTruthy();
       });
     }
   });

--- a/tests/qs.spec.ts
+++ b/tests/qs.spec.ts
@@ -18,6 +18,10 @@ describe('buildQueryString', () => {
     const result = buildQueryString({});
     expect(result).toBe('');
   });
+  it('call with an object and null value', () => {
+    const result = buildQueryString({ q: null });
+    expect(result).toBe('q=');
+  });
   it('call with a string value', () => {
     const result = buildQueryString({ q: 'value' });
     expect(result).toBe('q=value');

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,6 +2,7 @@
   "entryPoints": [
     "./src/geocode.ts",
     "./src/types/GeocodingRequest.ts",
-    "./src/types/GeocodingResponse.ts"
+    "./src/types/GeocodingResponse.ts",
+    "./src/types/GeocodingOptions.ts"
   ]
 }


### PR DESCRIPTION
Improves the API's semantic splitting of query parameters and technical options. 
The input.proxyURL parameter is now deprecated in favour of the options.proxyURL parameter. 

This PR also improves the test coverage.